### PR TITLE
Fix: models with world paths for gazebo

### DIFF
--- a/cucr_worlds_museum/CMakeLists.txt
+++ b/cucr_worlds_museum/CMakeLists.txt
@@ -5,23 +5,15 @@ add_compile_options(-std=c++11)
 
 find_package(gazebo_ros_link_attacher QUIET)
 
-if(gazebo_ros_link_attacher_FOUND)
 find_package(catkin REQUIRED
   COMPONENTS 
     roscpp
     moveit_core
     moveit_ros_planning
     moveit_ros_planning_interface
+    gazebo_ros
 )
-else()
-find_package(catkin REQUIRED
-  COMPONENTS
-    roscpp
-    moveit_core
-    moveit_ros_planning
-    moveit_ros_planning_interface
-)
-endif()
+
 
 find_package(Boost REQUIRED system filesystem date_time thread)
 
@@ -32,3 +24,7 @@ catkin_package(
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
+
+install(DIRECTORY models worlds
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/cucr_worlds_museum/package.xml
+++ b/cucr_worlds_museum/package.xml
@@ -26,4 +26,12 @@
   <depend>rqt_gui</depend>
   <depend>rviz</depend>
 
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo</exec_depend>
+  <exec_depend>gazebo_plugins</exec_depend>
+
+  <export>
+    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}" gazebo_model_path="${prefix}/models"/>
+  </export>
+
 </package>


### PR DESCRIPTION
# Description

I have modified `package.xml` and `CMakeLists.txt` to include the path of the models and world folder, also some gazebos dependencies just in case. I have also deleted an unused if-else statement in the `CMakeLists.txt`.